### PR TITLE
ci: upgrade gh actions to nodejs 16

### DIFF
--- a/.github/workflows/build_alfa_cli.yml
+++ b/.github/workflows/build_alfa_cli.yml
@@ -17,7 +17,7 @@ jobs:
       tag: ${{ steps.create-tag.outputs.tag }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: '0'
       - name: Bump version and create tag
@@ -42,7 +42,7 @@ jobs:
         os: [ ubuntu-latest, macos-latest ]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: '0'
 
@@ -70,7 +70,7 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: '0'
       - name: Setup arm emulation with qemu

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: '0'
 

--- a/.github/workflows/pr_title_linter.yml
+++ b/.github/workflows/pr_title_linter.yml
@@ -12,7 +12,7 @@ jobs:
     name: Conventional Commits
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v4
+      - uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/publish_dart_docker.yml
+++ b/.github/workflows/publish_dart_docker.yml
@@ -43,5 +43,5 @@ jobs:
         with:
           file: dart.Dockerfile
           build-args: IMAGE_NAME=${{ matrix.image }}
-          push: false
+          push: true
           tags: ${{ matrix.tags }}

--- a/.github/workflows/publish_dart_docker.yml
+++ b/.github/workflows/publish_dart_docker.yml
@@ -43,5 +43,5 @@ jobs:
         with:
           file: dart.Dockerfile
           build-args: IMAGE_NAME=${{ matrix.image }}
-          push: true
+          push: false
           tags: ${{ matrix.tags }}

--- a/.github/workflows/publish_dart_docker.yml
+++ b/.github/workflows/publish_dart_docker.yml
@@ -30,16 +30,16 @@ jobs:
             tags: nateateteen/zdartpod:full-min
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           file: dart.Dockerfile
           build-args: IMAGE_NAME=${{ matrix.image }}

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -34,16 +34,16 @@ jobs:
             min: yes
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           build-args: |
             IMAGE_NAME=${{ matrix.image }}

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -48,5 +48,5 @@ jobs:
           build-args: |
             IMAGE_NAME=${{ matrix.image }}
             MIN=${{ matrix.min }}
-          push: false
+          push: true
           tags: ${{ matrix.tags }}

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -48,5 +48,5 @@ jobs:
           build-args: |
             IMAGE_NAME=${{ matrix.image }}
             MIN=${{ matrix.min }}
-          push: true
+          push: false
           tags: ${{ matrix.tags }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: '0'
 


### PR DESCRIPTION
<!-- Please make sure you have read the contributing guidelines -->

## Description
<!-- Describe any changes you have made here -->
<!-- Also, reference any issue that this PR resolves -->
- upgrades GitHub actions to Node.js 16 to resolve warning messages
