### PR TITLE
ci: upgrade build and tests from ubuntu-22.04 to ubuntu-24.04, adds more dart versions to tests

### DIFF
--- a/.github/workflows/build_alfa_cli.yml
+++ b/.github/workflows/build_alfa_cli.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         include:
           - name: linux-x86
-            os: ubuntu-22.04
+            os: ubuntu-24.04
           - name: macos-arm
             os: macos-14
           - name: macos-x86
@@ -53,7 +53,7 @@ jobs:
 
   build-executable-on-arm:
     name: Build linux arm executable
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/build_alfa_cli.yml
+++ b/.github/workflows/build_alfa_cli.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         include:
           - name: linux-x86
-            os: ubuntu-24.04
+            os: ubuntu-22.04
           - name: macos-arm
             os: macos-14
           - name: macos-x86

--- a/.github/workflows/build_alfa_cli.yml
+++ b/.github/workflows/build_alfa_cli.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         include:
           - name: linux-x86
-            os: ubuntu-22.04
+            os: ubuntu-24.04
           - name: macos-arm
             os: macos-14
           - name: macos-x86

--- a/.github/workflows/build_alfa_cli.yml
+++ b/.github/workflows/build_alfa_cli.yml
@@ -53,7 +53,7 @@ jobs:
 
   build-executable-on-arm:
     name: Build linux arm executable
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
 
     steps:
@@ -70,7 +70,7 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
           sudo apt-get update -q -y
-          sudo apt-get -qq install -y qemu qemu-user-static
+          sudo apt-get -qq install -y qemu-user qemu-user-static
           docker run --rm --privileged multiarch/qemu-user-static --reset -p yes --credential yes
 
       - name: Create docker command script

--- a/.github/workflows/lint_dart.yml
+++ b/.github/workflows/lint_dart.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
 
   find-functions:
     name: Find functions that changed
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
     outputs:
       matrix: ${{ env.matrix }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,13 +152,13 @@ jobs:
       - name: Print help message
         if: ${{ !matrix.image }}
         run: |
-          sudo ./install.sh -h
+          ./install.sh -h
 
       - name: Test install
         if: ${{ !matrix.image }}
         run: |
           set -euo pipefail
-          sudo ./install.sh -e -c test/resources/functions/${{ matrix.name }}/test_config.toml -f test_install_list.txt 2>&1 | tee $ALFA_INSTALL_LOG_FILEPATH
+          ./install.sh -e -c test/resources/functions/${{ matrix.name }}/test_config.toml -f test_install_list.txt 2>&1 | tee $ALFA_INSTALL_LOG_FILEPATH
 
       - name: Create docker command script
         if: ${{ matrix.image }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
 
   test-functions-schema:
     name: Test functions schema
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     strategy:
       matrix:
@@ -181,7 +181,7 @@ jobs:
         if: ${{ matrix.image && matrix.platform == 'linux/arm64' }}
         run: |
           sudo apt-get update -q -y
-          sudo apt-get -qq install -y qemu qemu-user-static
+          sudo apt-get -qq install -y qemu-user qemu-user-static
           docker run --rm --privileged multiarch/qemu-user-static --reset -p yes --credential yes
 
       - name: Test install with docker

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        sdk: [stable, 3.0, 3.1, 3.2, 3.3, 3.4]
+        sdk: [stable, 3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6]
 
     steps:
       - uses: actions/checkout@v4

--- a/contributing-docs/04-how-to-test-functions.md
+++ b/contributing-docs/04-how-to-test-functions.md
@@ -31,7 +31,7 @@ Here is an example test runner toml file:
 
 ```toml
 [case.example]
-os = "ubuntu-22.04"
+os = "ubuntu-24.04"
 image = "phusion/baseimage:jammy-1.0.4"
 platform = "linux/amd64"
 

--- a/test/resources/functions/_example/runners.toml
+++ b/test/resources/functions/_example/runners.toml
@@ -17,7 +17,7 @@ assert-stdout-equals = "hi"
 
 # runs function on linux-x86 with a set of different setup/install/teardown steps
 [case.linux-x86]
-os = "ubuntu-22.04"
+os = "ubuntu-24.04"
 install-tag = "special-install"
 setup-tag = "setup-special"
 teardown-tag = "teardown-special"
@@ -30,12 +30,12 @@ assert-log-contains = ["runner called this function on a x86_64 computer\nspecia
 
 # runs function on linux x86 in a docker image
 [case.linux-x86-docker]
-os = "ubuntu-22.04"
+os = "ubuntu-24.04"
 image = "phusion/baseimage:jammy-1.0.4"
 
 # runs function on linux arm in a docker image
 [case.linux-arm]
-os = "ubuntu-22.04"
+os = "ubuntu-24.04"
 image = "phusion/baseimage:jammy-1.0.4"
 platform = "linux/arm64"
 

--- a/test/resources/functions/add_ohmyzsh_plugins/runners.toml
+++ b/test/resources/functions/add_ohmyzsh_plugins/runners.toml
@@ -11,7 +11,7 @@ arguments = [
 assert-stdout-contains = "plugins=(\n  git\n  copyfile\n  ### NEW PLUGINS HERE ###\n)\n"
 
 [case.linux]
-os = "ubuntu-22.04"
+os = "ubuntu-24.04"
 image = "phusion/baseimage:jammy-1.0.4"
 
 [case.linux.test]

--- a/test/resources/functions/anaconda/runners.toml
+++ b/test/resources/functions/anaconda/runners.toml
@@ -18,11 +18,11 @@ arguments = ["-ceu", "~/anaconda3/bin/conda --help"]
 assert-stdout-contains = "conda is a tool for managing and deploying applications, environments and packages."
 
 [case.linux-x86]
-os = "ubuntu-22.04"
+os = "ubuntu-24.04"
 image = "phusion/baseimage:jammy-1.0.4"
 
 [case.linux-arm]
-os = "ubuntu-22.04"
+os = "ubuntu-24.04"
 image = "phusion/baseimage:jammy-1.0.4"
 platform = "linux/arm64"
 

--- a/test/resources/functions/apt_get_packages/runners.toml
+++ b/test/resources/functions/apt_get_packages/runners.toml
@@ -1,5 +1,5 @@
 [case.default]
-os = "ubuntu-22.04"
+os = "ubuntu-24.04"
 image = "phusion/baseimage:jammy-1.0.4"
 
 [case.default.test]

--- a/test/resources/functions/awscli/runners.toml
+++ b/test/resources/functions/awscli/runners.toml
@@ -13,7 +13,7 @@ arguments = ["--version"]
 assert-stdout-contains = "aws-cli/2"
 
 [case.linux-x86]
-os = "ubuntu-22.04"
+os = "ubuntu-24.04"
 image = "phusion/baseimage:jammy-1.0.4"
 
 [case.linux-x86.test]
@@ -21,7 +21,7 @@ image = "phusion/baseimage:jammy-1.0.4"
 assert-install-names = ["apt_get_packages", "awscli"]
 
 [case.linux-arm]
-os = "ubuntu-22.04"
+os = "ubuntu-24.04"
 image = "phusion/baseimage:jammy-1.0.4"
 platform = "linux/arm64"
 

--- a/test/resources/functions/nvm/runners.toml
+++ b/test/resources/functions/nvm/runners.toml
@@ -1,5 +1,5 @@
 [common]
-os = "ubuntu-22.04"
+os = "ubuntu-24.04"
 image = "phusion/baseimage:jammy-1.0.4"
 
 [[common.test.commands]]

--- a/test/resources/functions/ohmyzsh/runners.toml
+++ b/test/resources/functions/ohmyzsh/runners.toml
@@ -1,6 +1,6 @@
 [common]
 
-os = "ubuntu-22.04"
+os = "ubuntu-24.04"
 image = "phusion/baseimage:jammy-1.0.4"
 
 setup-tag = "setup"

--- a/test/resources/functions/run_command/runners.toml
+++ b/test/resources/functions/run_command/runners.toml
@@ -8,7 +8,7 @@ assert-log-contains = [
 
 # runs on both linux and macos since the function uses sed
 [case.linux]
-os = "ubuntu-22.04"
+os = "ubuntu-24.04"
 
 [case.macos]
 os = "macos-13"

--- a/test/resources/functions/sdkman/runners.toml
+++ b/test/resources/functions/sdkman/runners.toml
@@ -1,5 +1,5 @@
 [case.default]
-os = "ubuntu-22.04"
+os = "ubuntu-24.04"
 image = "phusion/baseimage:jammy-1.0.4"
 
 setup-tag = "setup"

--- a/test/resources/functions/zshenv/runners.toml
+++ b/test/resources/functions/zshenv/runners.toml
@@ -1,5 +1,5 @@
 [case.default]
-os = "ubuntu-22.04"
+os = "ubuntu-24.04"
 
 [case.default.test]
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Please make sure you have read the contributing guidelines -->

## Description
<!-- Describe any changes you have made here -->
<!-- Also, reference any issue that this PR resolves -->
- upgrade GitHub action runners to build and test from ubuntu-22.04 to ubuntu-24.04
- runs tests on dart 3.5 and 3.6 as well
- drops sudo from `sudo ./install.sh` command in tests due to updated macos github action runner: https://github.com/actions/runner-images/issues/10484

## Testing
<!-- If needed, describe any testing that you have done -->
