### PR TITLE
feat(core): updates option to `--run-shell` to support running any shell after completion of the installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Alternatively, you can also pass the items you want to install directly in the c
 To install your config, run the install script from the repo's root directory. Here is what the command would look like if you want to install my config:
 
 ```shell
-./install.sh -c configs/nathaniel/config.toml -f configs/nathaniel/install_list.txt -e -r
+./install.sh -c configs/nathaniel/config.toml -f configs/nathaniel/install_list.txt -e -r zsh
 ```
 
 - The `--config` (`-c`) argument is required and sets the install configuration file to use.
@@ -56,8 +56,8 @@ To install your config, run the install script from the repo's root directory. H
 - You can pass multiple items to all the above options, and it will evaluate them in that order. For example,
   - `./install.sh -c config1.toml -c config2.toml -f list1.txt -f list2.txt`.
   - `./install.sh -c config1.toml -c config2.toml --install name1 --install name2`.
-- `--exit` (`-e`) runs it in strict mode (will fail and exit immediately if a step fails)
-- `--run-zsh` (`-r`) runs zsh after all of the installation is done so you can see the changes without restarting the terminal (I am bias towards zsh, but hope to make this installer a bit less opinionated in the future)
+- `--exit` (`-e`) runs it in strict mode (will fail and exit immediately if a step fails).
+- `--run-shell` (`-r`) runs the specified shell in login mode after the completion of the installation so you can see the changes without restarting the terminal.
 
 ## Other Cool Features
 

--- a/bin/alfa.dart
+++ b/bin/alfa.dart
@@ -31,8 +31,13 @@ void main(List<String> args) async {
   parser.addMultiOption('install',
       help:
           'Pass the items to install (names or tags) directly in the command line instead of using the --file option. Can pass multiple.');
+
+  // TODO: remove run-zsh flag with next major release (v2.X.X), keeping for backwards compatibility
   parser.addFlag('run-zsh',
-      abbr: 'r', help: 'Runs zsh at the end', negatable: false);
+      help: 'Runs zsh at the end', negatable: false, hide: true);
+
+  parser.addOption('run-shell',
+      abbr: 'r', help: 'Runs the specified shell in login mode at the end');
 
   late ArgResults argResults;
 

--- a/install.sh
+++ b/install.sh
@@ -76,25 +76,35 @@ else
 
 fi
 
-hasHelp="0"
-hasDryRun="0"
-hasRunShell="0"
+runShellFlag="0"
+shellToRun=""
 
-# checks if the help, dry-run, and run-zsh arguments were passed
+# additional checks after running the alfa executable
+# exits on help and dry-run
+# runs shell if the run-shell argument is passed
 for argument in "$@"
 do
   if [[ "$argument" == "-h" || "$argument" == "--help" ]]; then
-    hasHelp="1"
+    exit
   elif [[ "$argument" == "-n" || "$argument" == "--dry-run" ]]; then
-    hasDryRun="1"
-  elif [[ "$argument" == "-r" || "$argument" == "--run-zsh" ]]; then
-    hasRunShell="1"
+    exit
+  elif [[ "$argument" == "--run-zsh" ]]; then
+    # TODO: remove run-zsh flag with next major release (v2.X.X), keeping for backwards compatibility
+    shellToRun="zsh"
+  elif [[ "$argument" == "-r" || "$argument" == "--run-shell" ]]; then
+    runShellFlag="1"
+  elif [[ "$runShellFlag" == "1" ]]; then
+    shellToRun="$argument"
+    runShellFlag="0"
   fi
 done
 
-# runs zsh
-if [[ "$hasHelp" == "0" && "$hasDryRun" == "0" && "$hasRunShell" == "1" ]]; then
-  echo 'Run "chsh -s $(which zsh)" to change your default shell to zsh. Logout and log back in to see the changes.'
-  # runs zsh so you can see all the new changes
-  exec zsh -l
+# runs the shell
+if [[ -n "$shellToRun" ]]; then
+  echo
+  echo "--------------------------------------------"
+  echo 'Run "chsh -s $(which '"$shellToRun"')" to change your default shell to '"$shellToRun"'. Logout and log back in to see the changes.'
+  echo "Running a new '$shellToRun' shell in login mode..."
+  # runs the shell in login mode so you can see all the new changes
+  exec "$shellToRun" -l
 fi

--- a/install.sh
+++ b/install.sh
@@ -76,6 +76,7 @@ else
 
 fi
 
+hasRunZsh="0"
 runShellFlag="0"
 shellToRun=""
 
@@ -90,6 +91,7 @@ do
     exit
   elif [[ "$argument" == "--run-zsh" ]]; then
     # TODO: remove run-zsh flag with next major release (v2.X.X), keeping for backwards compatibility
+    hasRunZsh="1"
     shellToRun="zsh"
   elif [[ "$argument" == "-r" || "$argument" == "--run-shell" ]]; then
     runShellFlag="1"
@@ -103,6 +105,11 @@ done
 if [[ -n "$shellToRun" ]]; then
   echo
   echo "--------------------------------------------"
+  # TODO: remove hasRunZsh conditional on next major release (v2.X.X)
+  if [[ "$hasRunZsh" == "1" ]]; then
+    echo "Warning: the '--run-zsh' flag will be deprecated in v2. Please use '--run-shell zsh' instead."
+    echo
+  fi
   echo 'Run "chsh -s $(which '"$shellToRun"')" to change your default shell to '"$shellToRun"'. Logout and log back in to see the changes.'
   echo "Running a new '$shellToRun' shell in login mode..."
   # runs the shell in login mode so you can see all the new changes

--- a/install.sh
+++ b/install.sh
@@ -107,7 +107,7 @@ if [[ -n "$shellToRun" ]]; then
   echo "--------------------------------------------"
   # TODO: remove hasRunZsh conditional on next major release (v2.X.X)
   if [[ "$hasRunZsh" == "1" ]]; then
-    echo "Warning: the '--run-zsh' flag will be deprecated in v2. Please use '--run-shell zsh' instead."
+    echo "Warning: the '--run-zsh' flag is deprecated and will be removed in v2. Please use '--run-shell zsh' instead."
     echo
   fi
   echo 'Run "chsh -s $(which '"$shellToRun"')" to change your default shell to '"$shellToRun"'. Logout and log back in to see the changes.'


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Please make sure you have read the contributing guidelines -->

## Description
<!-- Describe any changes you have made here -->
<!-- Also, reference any issue that this PR resolves -->
- updates option to `--run-shell` to support running any shell after completion of the installation
- updates README
- adds deprecation warning for `--run-zsh` option

## Testing
<!-- If needed, describe any testing that you have done -->

```bash
./install.sh -e -c test/resources/functions/run_command/test_config.toml --install run_command --run-zsh
./install.sh -e -c test/resources/functions/run_command/test_config.toml --install run_command --run-shell zsh 
./install.sh -e -c test/resources/functions/run_command/test_config.toml --install run_command --run-shell bash
./install.sh -e -c test/resources/functions/run_command/test_config.toml --install run_command --run-shell fish
```

And in a docker image created with:

```bash
docker run --rm -it --workdir $PWD -v "$PWD:$PWD" --entrypoint bash phusion/baseimage:jammy-1.0.4
```

```bash
./install.sh -e -c test/resources/functions/ohmyzsh/test_config.toml --install apt_get_packages ohmyzsh --run-shell zsh 
```
