### PR TITLE
ci: upgrades macos runner to version 15

### DIFF
--- a/.github/workflows/build_alfa_cli.yml
+++ b/.github/workflows/build_alfa_cli.yml
@@ -16,9 +16,9 @@ jobs:
           - name: linux-x86
             os: ubuntu-24.04
           - name: macos-arm
-            os: macos-14
+            os: macos-15
           - name: macos-x86
-            os: macos-13
+            os: macos-15-intel
 
     steps:
       - uses: actions/checkout@v5

--- a/test/resources/functions/_example/runners.toml
+++ b/test/resources/functions/_example/runners.toml
@@ -41,8 +41,8 @@ platform = "linux/arm64"
 
 # runs function on macos arm
 [case.macos-arm]
-os = "macos-14"
+os = "macos-15"
 
 # runs function on macos x86
 [case.macos-x86]
-os = "macos-13"
+os = "macos-15-intel"

--- a/test/resources/functions/add_ohmyzsh_plugins/runners.toml
+++ b/test/resources/functions/add_ohmyzsh_plugins/runners.toml
@@ -19,7 +19,7 @@ image = "phusion/baseimage:jammy-1.0.4"
 assert-install-names = ["apt_get_packages", "ohmyzsh", "add_ohmyzsh_plugins"]
 
 [case.macos]
-os = "macos-13"
+os = "macos-15-intel"
 
 [case.macos.test]
 

--- a/test/resources/functions/anaconda/runners.toml
+++ b/test/resources/functions/anaconda/runners.toml
@@ -27,10 +27,10 @@ image = "phusion/baseimage:jammy-1.0.4"
 platform = "linux/arm64"
 
 [case.macos-arm]
-os = "macos-14"
+os = "macos-15"
 
 [case.macos-x86]
-os = "macos-13"
+os = "macos-15-intel"
 install-tag = "custom-location"
 
 [case.macos-x86.test]

--- a/test/resources/functions/awscli/runners.toml
+++ b/test/resources/functions/awscli/runners.toml
@@ -30,7 +30,7 @@ platform = "linux/arm64"
 assert-install-names = ["apt_get_packages", "awscli"]
 
 [case.macos-arm]
-os = "macos-14"
+os = "macos-15"
 
 [case.macos-x86]
-os = "macos-13"
+os = "macos-15-intel"

--- a/test/resources/functions/install_binary/runners.toml
+++ b/test/resources/functions/install_binary/runners.toml
@@ -22,7 +22,7 @@ arguments = [
 assert-stdout-contains = "-rwxrwxrwx"
 
 [case.http-macos]
-os = "macos-14"
+os = "macos-15"
 
 install-tag = "install_binary+macos"
 

--- a/test/resources/functions/run_command/runners.toml
+++ b/test/resources/functions/run_command/runners.toml
@@ -11,4 +11,4 @@ assert-log-contains = [
 os = "ubuntu-24.04"
 
 [case.macos]
-os = "macos-13"
+os = "macos-15-intel"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Please make sure you have read the contributing guidelines -->

## Description
<!-- Describe any changes you have made here -->
<!-- Also, reference any issue that this PR resolves -->
- upgrades macos runners to macos-15 and macos-15-intel
- macOS 13 is being deprecated: https://github.com/actions/runner-images/issues/13046

## Testing
<!-- If needed, describe any testing that you have done -->
