### PR TITLE
feat(core): updates `install.sh` and `download.sh` to use sh instead of bash

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,8 @@ on:
       - "functions/**"
       - "lib/**"
       - "test/**"
+      - "tools/download.sh"
+      - "install.sh"
       - "Makefile"
       - "pubspec.yaml"
   workflow_dispatch:

--- a/install.sh
+++ b/install.sh
@@ -127,7 +127,7 @@ if [ ! -f "$alfaCommand" ]; then
   fi
 
   if [ -f functions.sh ] && { [ "$version" = 'latest' ] || version_is_greater_than "$version" 'v1.1.0'; }; then
-    echo 'Get the lastest commit from origin/main or specify alfa version <= v1.1.0'
+    echo 'Get the latest commit from origin/main or specify alfa version <= v1.1.0'
     exit 1
   fi
 

--- a/install.sh
+++ b/install.sh
@@ -154,12 +154,12 @@ if [ ! -f "$alfaCommand" ]; then
   chmod +x "$alfaCommand"
 fi
 
+export ALFA_ARCH="$unameMachine"
+export ALFA_USER="${SUDO_USER:-${USER:-}}"
+
 if [ "$exitAfterAlfa" = '1' ]; then
   exec "./$alfaCommand" "$@"
 fi
-
-export ALFA_ARCH="$unameMachine"
-export ALFA_USER="${SUDO_USER:-${USER:-}}"
 
 # runs the alfa command depending upon if sudo exists
 if ! command -v sudo >/dev/null 2>&1; then

--- a/install.sh
+++ b/install.sh
@@ -85,7 +85,9 @@ runShellFlag='0'
 shellToRun=''
 exitAfterAlfa='0'
 
-# parse arguments that affect install.sh behavior
+# parse arguments from alfa executable that affect this script's behavior
+# skips sudo checks on --help and --dry-run flags
+# and runs a shell after installation if --run-zsh or --run-shell is provided
 for argument in "$@"
 do
   if [ "$argument" = '-h' ] || [ "$argument" = '--help' ]; then

--- a/install.sh
+++ b/install.sh
@@ -126,8 +126,8 @@ if [ ! -f "$alfaCommand" ]; then
     version="$(grep -Ev '^((//|#)|[[:space:]]*$)' version.txt | head -n 1 || true)"
   fi
 
-  if [ -f functions.sh ] && { [ "$version" = 'latest' ] || version_is_greater_than "$version" 'v1.1.0'; }; then
-    echo 'Get the latest commit from origin/main or specify alfa version <= v1.1.0'
+  if [ "$version" != 'latest' ] && ! version_is_greater_than "$version" 'v1.1.0'; then
+    echo 'Get the latest commit from origin/main or specify alfa version > v1.1.0 or "latest"'
     exit 1
   fi
 

--- a/install.sh
+++ b/install.sh
@@ -1,22 +1,118 @@
-#!/bin/bash
+#!/bin/sh
 
-set -euo pipefail
+set -eu
+
+version_is_greater_than() {
+  left="${1#v}"
+  right="${2#v}"
+
+  old_ifs=$IFS
+  IFS=.
+  set -- $left
+  IFS=$old_ifs
+  left_major=${1:-0}
+  left_minor=${2:-0}
+  left_patch=${3:-0}
+
+  IFS=.
+  set -- $right
+  IFS=$old_ifs
+  right_major=${1:-0}
+  right_minor=${2:-0}
+  right_patch=${3:-0}
+
+  if [ "$left_major" -gt "$right_major" ]; then
+    return 0
+  fi
+  if [ "$left_major" -lt "$right_major" ]; then
+    return 1
+  fi
+  if [ "$left_minor" -gt "$right_minor" ]; then
+    return 0
+  fi
+  if [ "$left_minor" -lt "$right_minor" ]; then
+    return 1
+  fi
+
+  [ "$left_patch" -gt "$right_patch" ]
+}
+
+cleanup_sudo_loop() {
+  if [ -n "${loopPid:-}" ]; then
+    command kill "$loopPid" 2>/dev/null || true
+    wait "$loopPid" 2>/dev/null || true
+    loopPid=''
+  fi
+}
+
+start_sudo_loop() {
+  (
+    sleepPid=''
+
+    cleanup_inner_loop() {
+      trap - INT TERM EXIT
+      if [ -n "$sleepPid" ]; then
+        command kill "$sleepPid" 2>/dev/null || true
+        wait "$sleepPid" 2>/dev/null || true
+        sleepPid=''
+      fi
+      exit 0
+    }
+
+    trap 'cleanup_inner_loop' INT TERM EXIT
+
+    while :
+    do
+      sudo -v || exit 1
+      sleep 59 &
+      sleepPid=$!
+      wait "$sleepPid"
+      sleepPid=''
+    done
+  ) &
+
+  loopPid=$!
+}
 
 # checks if install.sh is run from the correct directory
-if [[ ! -f "Makefile" ]]; then
+if [ ! -f Makefile ]; then
   echo "install.sh must be run from the root directory of the alfa repo"
   exit 1
 fi
 
-alfaCommand=""
+hasRunZsh='0'
+runShellFlag='0'
+shellToRun=''
+exitAfterAlfa='0'
+
+# parse arguments that affect install.sh behavior
+for argument in "$@"
+do
+  if [ "$argument" = '-h' ] || [ "$argument" = '--help' ]; then
+    exitAfterAlfa='1'
+  elif [ "$argument" = '-n' ] || [ "$argument" = '--dry-run' ]; then
+    exitAfterAlfa='1'
+  elif [ "$argument" = '--run-zsh' ]; then
+    # TODO: remove run-zsh flag with next major release (v2.X.X), keeping for backwards compatibility
+    hasRunZsh='1'
+    shellToRun='zsh'
+  elif [ "$argument" = '-r' ] || [ "$argument" = '--run-shell' ]; then
+    runShellFlag='1'
+  elif [ "$runShellFlag" = '1' ]; then
+    shellToRun="$argument"
+    runShellFlag='0'
+  fi
+done
+
+alfaCommand=''
 
 # gets the alfa executable name based on the operating system and architecture
 unameSystem="$(uname -s)"
 unameMachine="$(uname -m)"
 
-if [[ "Linux" == "$unameSystem" && ( "x86_64" == "$unameMachine" || "aarch64" == "$unameMachine" ) ]]; then
+if [ "$unameSystem" = 'Linux' ] && { [ "$unameMachine" = 'x86_64' ] || [ "$unameMachine" = 'aarch64' ]; }; then
   alfaCommand="alfa_linux_$unameMachine"
-elif [[ "Darwin" == "$unameSystem" && ( "x86_64" == "$unameMachine" || "arm64" == "$unameMachine" ) ]]; then
+elif [ "$unameSystem" = 'Darwin' ] && { [ "$unameMachine" = 'x86_64' ] || [ "$unameMachine" = 'arm64' ]; }; then
   alfaCommand="alfa_macos_$unameMachine"
 else
   echo "alfa cannot run on ${unameSystem} ${unameMachine}. It can only run on Linux and macOS."
@@ -24,89 +120,79 @@ else
 fi
 
 # downloads executable if it does not exist already
-if [[ ! -f "$alfaCommand" ]]; then
-  version=""
-  if [[ -f "version.txt" ]]; then
-    version=`cat version.txt | grep -Ev '^((//|#)|[[:space:]]*$)' | head -n 1`
+if [ ! -f "$alfaCommand" ]; then
+  version=''
+  if [ -f version.txt ]; then
+    version="$(grep -Ev '^((//|#)|[[:space:]]*$)' version.txt | head -n 1 || true)"
   fi
 
-  if [[ -f "functions.sh" && ( "$version" == "latest" || "$version" > "v1.1.0" ) ]]; then
-    echo "Get the lastest commit from origin/main or specify alfa version <= v1.1.0"
+  if [ -f functions.sh ] && { [ "$version" = 'latest' ] || version_is_greater_than "$version" 'v1.1.0'; }; then
+    echo 'Get the lastest commit from origin/main or specify alfa version <= v1.1.0'
     exit 1
   fi
 
-  if [[ -z "$version" || -z "$(echo $version | grep -E '^v[0-9]+.[0-9]+.[0-9]+$')" ]]; then
-    if ! command -v "git" > /dev/null 2>&1; then
-      echo "Must have git installed to download the latest version"
+  if [ -z "$version" ] || ! printf '%s\n' "$version" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+    if ! command -v git >/dev/null 2>&1; then
+      echo 'Must have git installed to download the latest version'
       exit 1
     fi
-    version=`git tag -l --sort=-v:refname | grep -E '^v[0-9]+.[0-9]+.[0-9]+$' | head -n 1`
+    version="$(git tag -l --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)"
+  fi
+
+  if [ -z "$version" ]; then
+    echo 'Unable to determine which alfa version to download'
+    exit 1
   fi
 
   url="https://github.com/nyoungstudios/alfa/releases/download/${version}/${alfaCommand}"
 
-  source tools/download.sh; curl_or_wget -s "$url" "$alfaCommand"
+  . ./tools/download.sh
+  curl_or_wget -s "$url" "$alfaCommand"
 
   chmod +x "$alfaCommand"
+fi
 
+if [ "$exitAfterAlfa" = '1' ]; then
+  exec "./$alfaCommand" "$@"
 fi
 
 export ALFA_ARCH="$unameMachine"
 export ALFA_USER="${SUDO_USER:-${USER:-}}"
 
 # runs the alfa command depending upon if sudo exists
-if ! command -v "sudo" > /dev/null 2>&1; then
+if ! command -v sudo >/dev/null 2>&1; then
   # sudo command doesn't exist
-  ./$alfaCommand "$@"
+  "./$alfaCommand" "$@"
 else
   # sudo command exists
-
-  if [[ "$EUID" -eq 0 && "${SUDO_GID:-1}" -eq 0 ]]; then
-    echo "Some things may not install properly if this is called as root. This script will call sudo when needed."
+  if [ "$(id -u)" -eq 0 ] && [ "${SUDO_GID:-1}" -eq 0 ]; then
+    echo 'Some things may not install properly if this is called as root. This script will call sudo when needed.'
   fi
 
   sudo -v
-  # keep refreshing sudo in the background every 59 seconds
-  while :; do sudo -v; sleep 59; done &
-  loopPid="$!"
+  start_sudo_loop
+  trap 'cleanup_sudo_loop' INT TERM EXIT
 
-  trap 'trap - SIGTERM && kill $(pgrep -P $loopPid) $loopPid' SIGINT SIGTERM EXIT
+  if sudo --preserve-env=ALFA_USER,ALFA_ARCH "./$alfaCommand" "$@"; then
+    alfaStatus=0
+  else
+    alfaStatus=$?
+  fi
 
-  sudo --preserve-env=ALFA_USER,ALFA_ARCH ./$alfaCommand "$@"
+  cleanup_sudo_loop
+  trap - INT TERM EXIT
 
+  if [ "$alfaStatus" -ne 0 ]; then
+    exit "$alfaStatus"
+  fi
 fi
 
-hasRunZsh="0"
-runShellFlag="0"
-shellToRun=""
-
-# additional checks after running the alfa executable
-# exits on help and dry-run
-# runs shell if the run-shell argument is passed
-for argument in "$@"
-do
-  if [[ "$argument" == "-h" || "$argument" == "--help" ]]; then
-    exit
-  elif [[ "$argument" == "-n" || "$argument" == "--dry-run" ]]; then
-    exit
-  elif [[ "$argument" == "--run-zsh" ]]; then
-    # TODO: remove run-zsh flag with next major release (v2.X.X), keeping for backwards compatibility
-    hasRunZsh="1"
-    shellToRun="zsh"
-  elif [[ "$argument" == "-r" || "$argument" == "--run-shell" ]]; then
-    runShellFlag="1"
-  elif [[ "$runShellFlag" == "1" ]]; then
-    shellToRun="$argument"
-    runShellFlag="0"
-  fi
-done
-
 # runs the shell
-if [[ -n "$shellToRun" ]]; then
+if [ -n "$shellToRun" ]; then
   echo
-  echo "--------------------------------------------"
+  echo '--------------------------------------------'
   # TODO: remove hasRunZsh conditional on next major release (v2.X.X)
-  if [[ "$hasRunZsh" == "1" ]]; then
+  if [ "$hasRunZsh" = '1' ]; then
     echo "Warning: the '--run-zsh' flag is deprecated and will be removed in v2. Please use '--run-shell zsh' instead."
     echo
   fi

--- a/test/resources/functions/install_binary/test_config.toml
+++ b/test/resources/functions/install_binary/test_config.toml
@@ -26,4 +26,3 @@ options = [
 options = [
   "/tmp/hello"
 ]
-# comment

--- a/test/resources/functions/install_binary/test_config.toml
+++ b/test/resources/functions/install_binary/test_config.toml
@@ -26,3 +26,4 @@ options = [
 options = [
   "/tmp/hello"
 ]
+# comment

--- a/tools/download.sh
+++ b/tools/download.sh
@@ -25,30 +25,26 @@ curl_or_wget() {
   fi
 
   if command -v curl >/dev/null 2>&1; then
-    # if curl is installed
+    curl_opts='-L'
     if [ "$silent" = '1' ]; then
-      if [ -n "$output" ]; then
-        curl -fsSL -o "$output" "$url"
-      else
-        curl -fsSL "$url"
-      fi
-    elif [ -n "$output" ]; then
-      curl -L -o "$output" "$url"
+      curl_opts='-fsSL'
+    fi
+
+    if [ -n "$output" ]; then
+      curl $curl_opts -o "$output" "$url"
     else
-      curl -L "$url"
+      curl $curl_opts "$url"
     fi
   elif command -v wget >/dev/null 2>&1; then
-    # if wget is installed
+    wget_opts=''
     if [ "$silent" = '1' ]; then
-      if [ -n "$output" ]; then
-        wget -q -O "$output" "$url"
-      else
-        wget -q -O - "$url"
-      fi
-    elif [ -n "$output" ]; then
-      wget -O "$output" "$url"
+      wget_opts='-q'
+    fi
+
+    if [ -n "$output" ]; then
+      wget $wget_opts -O "$output" "$url"
     else
-      wget -O - "$url"
+      wget $wget_opts -O - "$url"
     fi
   else
     echo 'Must have curl or wget installed'

--- a/tools/download.sh
+++ b/tools/download.sh
@@ -33,9 +33,9 @@ curl_or_wget() {
     fi
 
     if [ -n "$output" ]; then
-      curl $curl_opts -o "$output" "$url"
+      curl "$curl_opts" -o "$output" "$url"
     else
-      curl $curl_opts "$url"
+      curl "$curl_opts" "$url"
     fi
   elif command -v wget >/dev/null 2>&1; then
     wget_opts=''
@@ -44,9 +44,9 @@ curl_or_wget() {
     fi
 
     if [ -n "$output" ]; then
-      wget $wget_opts -O "$output" "$url"
+      wget "$wget_opts" -O "$output" "$url"
     else
-      wget $wget_opts -O - "$url"
+      wget "$wget_opts" -O - "$url"
     fi
   else
     echo 'Must have curl or wget installed'

--- a/tools/download.sh
+++ b/tools/download.sh
@@ -9,6 +9,7 @@ curl_or_wget() {
   # url is the url to download
   # output file is where to save the url contents to. Will output to stdout if not provided.
 
+  # flags
   silent='0'
 
   if [ "${1:-}" = '-s' ]; then
@@ -16,6 +17,7 @@ curl_or_wget() {
     shift
   fi
 
+  # sets positional arguments
   url="${1:-}"
   output="${2:-}"
 

--- a/tools/download.sh
+++ b/tools/download.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -eu
 
@@ -9,69 +9,49 @@ curl_or_wget() {
   # url is the url to download
   # output file is where to save the url contents to. Will output to stdout if not provided.
 
-  # flags
-  silent=0
+  silent='0'
 
-  # sets input arguments
-  newArgs=()
+  if [ "${1:-}" = '-s' ]; then
+    silent='1'
+    shift
+  fi
 
-  for arg in "$@"
-  do
-    if [[ "$arg" == "-s" ]];
-    then
-      silent=1
-    else
-      newArgs+=("$arg")
-    fi
-  done
-
-  set -- "${newArgs[@]}"
-
-  # sets positional arguments
   url="${1:-}"
   output="${2:-}"
 
-  if [[ -z "$url" ]];
-  then
-    echo "Must provide url"
+  if [ -z "$url" ]; then
+    echo 'Must provide url'
     exit 1
   fi
 
-  commandToRun=""
-
-  if command -v "curl" > /dev/null 2>&1; then
+  if command -v curl >/dev/null 2>&1; then
     # if curl is installed
-    commandToRun="curl -L"
-    if [[ "$silent" == 1 ]];
-    then
-      commandToRun="$commandToRun -fsS"
-    fi
-
-    if ! [[ -z "$output" ]];
-    then
-      commandToRun="$commandToRun -o '$output'"
-    fi
-  elif command -v "wget" > /dev/null 2>&1; then
-    # if wget is installed
-    commandToRun="wget"
-    if [[ "$silent" == 1 ]];
-    then
-      commandToRun="$commandToRun -q"
-    fi
-
-    if [[ -z "$output" ]];
-    then
-      commandToRun="$commandToRun -O-"
+    if [ "$silent" = '1' ]; then
+      if [ -n "$output" ]; then
+        curl -fsSL -o "$output" "$url"
+      else
+        curl -fsSL "$url"
+      fi
+    elif [ -n "$output" ]; then
+      curl -L -o "$output" "$url"
     else
-      commandToRun="$commandToRun -O '$output'"
+      curl -L "$url"
+    fi
+  elif command -v wget >/dev/null 2>&1; then
+    # if wget is installed
+    if [ "$silent" = '1' ]; then
+      if [ -n "$output" ]; then
+        wget -q -O "$output" "$url"
+      else
+        wget -q -O - "$url"
+      fi
+    elif [ -n "$output" ]; then
+      wget -O "$output" "$url"
+    else
+      wget -O - "$url"
     fi
   else
-    echo "Must have curl or wget installed"
+    echo 'Must have curl or wget installed'
     exit 1
   fi
-
-  commandToRun="$commandToRun '$url'"
-
-  eval $commandToRun
-
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Please make sure you have read the contributing guidelines -->

## Description
<!-- Describe any changes you have made here -->
<!-- Also, reference any issue that this PR resolves -->
- switches `install.sh` and `tools/download.sh` to use `/bin/sh` instead of `/bin/bash` for wider compatibility. Add both as paths to trigger tests in GitHub Actions
- fixes bug in version check in `install.sh`
- running `./install.sh` with `-h` or `--dry-run` doesn't require sudo access anymore

## Testing
<!-- If needed, describe any testing that you have done -->

New download script still can be called from alfa executable. Testing:

```
./install.sh -c test/resources/functions/install_binary/test_config.toml --install "install_binary+linux"
```

Ran `make clean` and `./install.sh -h` with various versions in the version.txt file to make sure the new `version_is_greater_than` function works

Ran `./install.sh -h` many times and then `ps aux` to make sure the trap works as expected