### PR TITLE
build: makes `.dart` folder in `dart.Dockerfile` owned by non-root user

### DIFF
--- a/dart.Dockerfile
+++ b/dart.Dockerfile
@@ -26,13 +26,13 @@ RUN find /etc/apt/sources.list.d/ -name "*nginx*" -delete; \
 # sets path
 ENV PATH="$PATH:/usr/lib/dart/bin"
 
+# sets user back to gitpod
+USER $_USER
+
 WORKDIR /home/$_USER/.dart
 
 # copies dart config files
 COPY --chown=$_USER .dart_config/ .
-
-# sets user back to gitpod
-USER $_USER
 
 RUN dart --disable-analytics && \
     echo "\ndart-tool=$(date '+%Y-%m-%d'),1" >> ~/.dart-tool/dart-flutter-telemetry.config

--- a/dart.Dockerfile
+++ b/dart.Dockerfile
@@ -29,7 +29,7 @@ ENV PATH="$PATH:/usr/lib/dart/bin"
 WORKDIR /home/$_USER/.dart
 
 # copies dart config files
-ADD .dart_config/ .
+COPY --chown=$_USER .dart_config/ .
 
 # sets user back to gitpod
 USER $_USER


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Please make sure you have read the contributing guidelines -->

## Description
<!-- Describe any changes you have made here -->
<!-- Also, reference any issue that this PR resolves -->
- makes `.dart` folder in `dart.Dockerfile` owned by non-root user
-

## Testing
<!-- If needed, describe any testing that you have done -->
- Codespaces built successfully
