### PR TITLE
build: creates artifacts for linux armv7 and riscv64 architectures

### DIFF
--- a/.github/workflows/build_alfa_cli.yml
+++ b/.github/workflows/build_alfa_cli.yml
@@ -48,8 +48,12 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: dart pub get
 
-      - name: Compile executable
-        if: steps.cache.outputs.cache-hit != 'true'
+      - name: Native compile executable
+        if: steps.cache.outputs.cache-hit != 'true' && ! matrix.cross-compile
+        run: make
+
+      - name: Cross compile executable
+        if: steps.cache.outputs.cache-hit != 'true' && matrix.cross-compile
         env:
           CROSS_COMPILE_TARGET: ${{ matrix.cross-compile }}
         run: make "$CROSS_COMPILE_TARGET"

--- a/.github/workflows/build_alfa_cli.yml
+++ b/.github/workflows/build_alfa_cli.yml
@@ -19,6 +19,12 @@ jobs:
             os: macos-15
           - name: macos-x86
             os: macos-15-intel
+          - name: linux-armv7
+            os: ubuntu-24.04
+            cross-compile: alfa_linux_armv7
+          - name: linux-riscv64
+            os: ubuntu-24.04
+            cross-compile: alfa_linux_riscv64
 
     steps:
       - uses: actions/checkout@v6
@@ -44,7 +50,9 @@ jobs:
 
       - name: Compile executable
         if: steps.cache.outputs.cache-hit != 'true'
-        run: make
+        env:
+          CROSS_COMPILE_TARGET: ${{ matrix.cross-compile }}
+        run: make "$CROSS_COMPILE_TARGET"
 
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -194,7 +194,7 @@ jobs:
           chmod +x run.sh
 
       - name: Setup arm emulation with qemu
-        if: ${{ matrix.image && matrix.platform == 'linux/arm64' }}
+        if: ${{ matrix.image && matrix.platform }}
         run: |
           sudo apt-get update -q -y
           sudo apt-get -qq install -y qemu-user qemu-user-static

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,11 @@ all: build
 
 help:
 	@echo 'help - Show this message'
-	@echo 'build - compiles an alfa executable'
-	@echo 'clean - remove alfa executable'
+	@echo 'build - compiles an alfa executable for the current operating system and architecture'
+	@echo 'alfa_linux_armv7 - cross compiles an alfa executable for linux armv7'
+	@echo 'alfa_linux_aarch64 - cross compiles an alfa executable for linux aarch64'
+	@echo 'alfa_linux_riscv64 - cross compiles an alfa executable for linux riscv64'
+	@echo 'clean - remove native and cross compiled alfa executables'
 	@echo 'clean-cache - remove dart package files'
 	@echo 'clean-all - runs clean and clean cache'
 	@echo 'lint - runs the dart linter'

--- a/Makefile
+++ b/Makefile
@@ -20,13 +20,13 @@ $(BIN_NAME): $(SRCS)
 build: $(BIN_NAME)
 
 alfa_linux_armv7: $(SRCS)
-	dart compile exe bin/alfa.dart --target-os=linux --target-arch=arm -o alfa_linux_armv7
+	dart compile exe bin/alfa.dart --target-os linux --target-arch arm -o alfa_linux_armv7
 
 alfa_linux_aarch64: $(SRCS)
-	dart compile exe bin/alfa.dart --target-os=linux --target-arch=arm64 -o alfa_linux_aarch64
+	dart compile exe bin/alfa.dart --target-os linux --target-arch arm64 -o alfa_linux_aarch64
 
 alfa_linux_riscv64: $(SRCS)
-	dart compile exe bin/alfa.dart --target-os=linux --target-arch=riscv64 -o alfa_linux_riscv64
+	dart compile exe bin/alfa.dart --target-os linux --target-arch riscv64 -o alfa_linux_riscv64
 
 clean:
 	rm -f $(BIN_NAME) alfa_linux_armv7 alfa_linux_aarch64 alfa_linux_riscv64

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,17 @@ $(BIN_NAME): $(SRCS)
 
 build: $(BIN_NAME)
 
+alfa_linux_armv7: $(SRCS)
+	dart compile exe bin/alfa.dart --target-os=linux --target-arch=arm -o alfa_linux_armv7
+
+alfa_linux_aarch64: $(SRCS)
+	dart compile exe bin/alfa.dart --target-os=linux --target-arch=arm64 -o alfa_linux_aarch64
+
+alfa_linux_riscv64: $(SRCS)
+	dart compile exe bin/alfa.dart --target-os=linux --target-arch=riscv64 -o alfa_linux_riscv64
+
 clean:
-	rm -f $(BIN_NAME)
+	rm -f $(BIN_NAME) alfa_linux_armv7 alfa_linux_aarch64 alfa_linux_riscv64
 
 clean-cache:
 	rm -rf .dart_tool .packages pubspec.lock

--- a/get_executable_name.sh
+++ b/get_executable_name.sh
@@ -6,10 +6,30 @@ set -eu
 unameSystem="$(uname -s)"
 unameMachine="$(uname -m)"
 
-if [ "$unameSystem" = "Linux" ] && { [ "$unameMachine" = "x86_64" ] || [ "$unameMachine" = "aarch64" ]; }; then
+if [ "$unameSystem" = "Linux" ]; then
   alfaCommand="alfa_linux_$unameMachine"
-elif [ "$unameSystem" = "Darwin" ] && { [ "$unameMachine" = "x86_64" ] || [ "$unameMachine" = "arm64" ]; }; then
-  alfaCommand="alfa_macos_$unameMachine"
+  case "$unameMachine" in
+    x86_64|aarch64|riscv64)
+      alfaCommand="alfa_linux_$unameMachine"
+      ;;
+    armv7l)
+      alfaCommand="alfa_linux_arm7"
+      ;;
+    *)
+      echo "alfa cannot run on Linux for architecture: ${unameMachine}"
+      exit 1
+      ;;
+  esac
+elif [ "$unameSystem" = "Darwin" ]; then
+  case "$unameMachine" in
+    x86_64|arm64)
+      alfaCommand="alfa_macos_$unameMachine"
+      ;;
+    *)
+      echo "alfa cannot run on macOS for architecture: $unameMachine"
+      exit 1
+      ;;
+  esac
 else
   echo "alfa cannot run on ${unameSystem} ${unameMachine}. It can only run on Linux and macOS."
   exit 1

--- a/get_executable_name.sh
+++ b/get_executable_name.sh
@@ -13,7 +13,7 @@ if [ "$unameSystem" = "Linux" ]; then
       alfaCommand="alfa_linux_$unameMachine"
       ;;
     armv7l)
-      alfaCommand="alfa_linux_arm7"
+      alfaCommand="alfa_linux_armv7"
       ;;
     *)
       echo "alfa cannot run on Linux for architecture: ${unameMachine}"

--- a/install.sh
+++ b/install.sh
@@ -119,7 +119,7 @@ if [ "$unameSystem" = "Linux" ]; then
       alfaCommand="alfa_linux_$unameMachine"
       ;;
     armv7l)
-      alfaCommand="alfa_linux_arm7"
+      alfaCommand="alfa_linux_armv7"
       ;;
     *)
       echo "alfa cannot run on Linux for architecture: ${unameMachine}"

--- a/install.sh
+++ b/install.sh
@@ -112,10 +112,30 @@ alfaCommand=''
 unameSystem="$(uname -s)"
 unameMachine="$(uname -m)"
 
-if [ "$unameSystem" = 'Linux' ] && { [ "$unameMachine" = 'x86_64' ] || [ "$unameMachine" = 'aarch64' ]; }; then
+if [ "$unameSystem" = "Linux" ]; then
   alfaCommand="alfa_linux_$unameMachine"
-elif [ "$unameSystem" = 'Darwin' ] && { [ "$unameMachine" = 'x86_64' ] || [ "$unameMachine" = 'arm64' ]; }; then
-  alfaCommand="alfa_macos_$unameMachine"
+  case "$unameMachine" in
+    x86_64|aarch64|riscv64)
+      alfaCommand="alfa_linux_$unameMachine"
+      ;;
+    armv7l)
+      alfaCommand="alfa_linux_arm7"
+      ;;
+    *)
+      echo "alfa cannot run on Linux for architecture: ${unameMachine}"
+      exit 1
+      ;;
+  esac
+elif [ "$unameSystem" = "Darwin" ]; then
+  case "$unameMachine" in
+    x86_64|arm64)
+      alfaCommand="alfa_macos_$unameMachine"
+      ;;
+    *)
+      echo "alfa cannot run on macOS for architecture: $unameMachine"
+      exit 1
+      ;;
+  esac
 else
   echo "alfa cannot run on ${unameSystem} ${unameMachine}. It can only run on Linux and macOS."
   exit 1

--- a/test/resources/functions/_example/runners.toml
+++ b/test/resources/functions/_example/runners.toml
@@ -31,13 +31,23 @@ assert-log-contains = ["runner called this function on a x86_64 computer\nspecia
 # runs function on linux x86 in a docker image
 [case.linux-x86-docker]
 os = "ubuntu-24.04"
-image = "phusion/baseimage:jammy-1.0.4"
+image = "ubuntu:24.04"
 
 # runs function on linux arm in a docker image
 [case.linux-arm]
 os = "ubuntu-24.04"
-image = "phusion/baseimage:jammy-1.0.4"
+image = "ubuntu:24.04"
 platform = "linux/arm64"
+
+[case.linux-riscv64]
+os = "ubuntu-24.04"
+image = "ubuntu:24.04"
+platform = "linux/riscv64"
+
+[case.linux-armv7]
+os = "ubuntu-24.04"
+image = "ubuntu:24.04"
+platform = "linux/arm/v7"
 
 # runs function on macos arm
 [case.macos-arm]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Please make sure you have read the contributing guidelines -->

## Description
<!-- Describe any changes you have made here -->
<!-- Also, reference any issue that this PR resolves -->
- creates the alfa executable artifacts for linux armv7 and riscv64 architectures
-

## Testing
<!-- If needed, describe any testing that you have done -->
