### PR TITLE
chore(configs): removes `zsh_successful_cmd_filter` from nathaniel config

### DIFF
--- a/configs/nathaniel/config.toml
+++ b/configs/nathaniel/config.toml
@@ -177,9 +177,6 @@ options = [
 [ ohmyzsh ]
 tags = [ "terminal" ]
 
-[ zsh_successful_cmd_filter ]
-tags = [ "terminal" ]
-
 [ install_ohmyzsh_plugins ]
 tags = [ "terminal" ]
 options = [


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Please make sure you have read the contributing guidelines -->

## Description
<!-- Describe any changes you have made here -->
<!-- Also, reference any issue that this PR resolves -->
- removes `zsh_successful_cmd_filter` from nathaniel config since it no longer exists
-

## Testing
<!-- If needed, describe any testing that you have done -->
