### PR TITLE
build: updates dart install for ubuntu 26.04

### DIFF
--- a/dart.Dockerfile
+++ b/dart.Dockerfile
@@ -9,19 +9,15 @@ ARG _USER="gitpod"
 USER root
 
 # install dart
-RUN find /etc/apt/sources.list.d/ -name "*nginx*" -delete; \
-    apt-get update && \
-    apt-get install -y --no-install-recommends gnupg2 curl git ca-certificates apt-transport-https openssh-client && \
-    curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
-    curl https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list && \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates curl gnupg && \
+    install -d -m 0755 /etc/apt/keyrings && \
+    curl -fsSL https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /etc/apt/keyrings/dart.gpg && \
+    chmod a+r /etc/apt/keyrings/dart.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/dart.gpg] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main" > /etc/apt/sources.list.d/dart_stable.list && \
     apt-get update && \
     apt-get install -y --no-install-recommends dart && \
-    apt-get clean -y && \
-    rm -rf \
-	    /var/cache/debconf/* \
-	    /var/lib/apt/lists/* \
-	    /tmp/* \
-	    /var/tmp/*
+    rm -rf /var/lib/apt/lists/*
 
 # sets path
 ENV PATH="$PATH:/usr/lib/dart/bin"

--- a/dart.Dockerfile
+++ b/dart.Dockerfile
@@ -9,7 +9,8 @@ ARG _USER="gitpod"
 USER root
 
 # install dart
-RUN apt-get update && \
+RUN find /etc/apt/sources.list.d/ -name "*nginx*" -delete && \
+    apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates curl gnupg && \
     install -d -m 0755 /etc/apt/keyrings && \
     curl -fsSL https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /etc/apt/keyrings/dart.gpg && \


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- Please make sure you have read the contributing guidelines -->

## Description
<!-- Describe any changes you have made here -->
<!-- Also, reference any issue that this PR resolves -->
- the base image `mcr.microsoft.com/devcontainers/base:ubuntu` for the dev container now uses ubuntu-26.04. Updates how we install dart to be compatible. Tested this on GitHub Codespaces which still caches the 24.04 version. It still works too
-

## Testing
<!-- If needed, describe any testing that you have done -->
